### PR TITLE
fixes deploy action

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -23,5 +23,5 @@ jobs:
         key: ${{ secrets.SERVER_KEY }}
         command: |
           cd /koala
-          export IMAGE_TAG=${{  github.ref_name }}
+          export IMAGE_TAG=v${{ github.ref_name }}
           docker compose up -d --remove-orphans


### PR DESCRIPTION
ref_name does removes the 'v' in v0.5.0. So we need to add it manually.