### PR TITLE
fixes parsing config env numbers

### DIFF
--- a/apps/api/src/app/config/config.module.ts
+++ b/apps/api/src/app/config/config.module.ts
@@ -9,6 +9,10 @@ export const ConfigModule = TypedConfigModule.forRoot({
       separator: '__',
     }),
   ],
+  normalize(config) {
+    config.mail.port = parseInt(config.mail.port, 10);
+    return config;
+  },
 });
 
 export const config = selectConfig(ConfigModule, Config);


### PR DESCRIPTION
Environment variables are always loaded as strings, but configuration schemas are not.