### PR TITLE
fixes wave / annotation container width

### DIFF
--- a/apps/koala-frontend/src/app/features/sessions/components/audio-wave/audio-wave.component.scss
+++ b/apps/koala-frontend/src/app/features/sessions/components/audio-wave/audio-wave.component.scss
@@ -1,4 +1,4 @@
 #wavesurfer-container {
   margin-left: 30px;
-  margin-right: 44px;
+  margin-right: 59px;
 }


### PR DESCRIPTION
both wave and annotation timeline need to have the exact same width. This was broken due to the delete annotation button