### PR TITLE
Multiple Improvements to Text Comment Maintenance and Display

### DIFF
--- a/apps/koala-frontend/src/app/app.component.html
+++ b/apps/koala-frontend/src/app/app.component.html
@@ -15,3 +15,5 @@
 <p-toast></p-toast>
 
 <koala-user-profile [(visible)]="showUserProfileDialog"></koala-user-profile>
+
+<p-confirmDialog [style]="{ width: '50vw' }" rejectButtonStyleClass="p-button-outlined"></p-confirmDialog>

--- a/apps/koala-frontend/src/app/app.module.ts
+++ b/apps/koala-frontend/src/app/app.module.ts
@@ -25,6 +25,7 @@ import { AuthModule } from './features/auth/auth.module';
 import { LayoutComponent } from './layout.component';
 import { ToastModule } from 'primeng/toast';
 import { MessageService, ConfirmationService } from 'primeng/api';
+import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { AuthInterceptor } from './features/auth/http-interceptors/auth-interceptor';
 import { getMainDefinition } from '@apollo/client/utilities';
 import { OperationDefinitionNode } from 'graphql';
@@ -59,6 +60,7 @@ export function HttpLoaderFactory(http: HttpClient) {
       },
     }),
     ToastModule,
+    ConfirmDialogModule,
   ],
   providers: [
     [

--- a/apps/koala-frontend/src/app/features/sessions/components/annotation-text-comment-list/annotation-text-comment-list.component.css
+++ b/apps/koala-frontend/src/app/features/sessions/components/annotation-text-comment-list/annotation-text-comment-list.component.css
@@ -1,3 +1,17 @@
 .full-width {
   width: 100%;
 }
+
+.box {
+  width: 20px;
+  height: 20px;
+  position: relative;
+}
+
+.own-comment-legend {
+  background-color: #248bf5;
+}
+
+.other-comment-legend {
+  background-color: #e5e5ea;
+}

--- a/apps/koala-frontend/src/app/features/sessions/components/annotation-text-comment-list/annotation-text-comment-list.component.html
+++ b/apps/koala-frontend/src/app/features/sessions/components/annotation-text-comment-list/annotation-text-comment-list.component.html
@@ -18,8 +18,15 @@
   </div>
 </div>
 
-<div style="margin-top: 20px; margin-bottom: 30px" *ngIf="comments?.length ? true : false">
+<div
+  style="margin-top: 20px; margin-bottom: 30px; display: flex; align-items: center; gap: 10px"
+  *ngIf="comments?.length ? true : false"
+>
   <h3>{{ 'SESSION.ANNOTATION.DETAIL_OVERLAY.ALL_COMMENTS_TITLE' | translate }}</h3>
+  <div class="box own-comment-legend"></div>
+  {{ 'SESSION.ANNOTATION.DETAIL_OVERLAY.OWN_COMMENT_LEGEND' | translate }}
+  <div class="box other-comment-legend"></div>
+  {{ 'SESSION.ANNOTATION.DETAIL_OVERLAY.OTHER_COMMENT_LEGEND' | translate }}
 </div>
 
 <!--Existing Comments List-->

--- a/apps/koala-frontend/src/app/features/sessions/components/annotation-text-comment-list/annotation-text-comment-list.component.ts
+++ b/apps/koala-frontend/src/app/features/sessions/components/annotation-text-comment-list/annotation-text-comment-list.component.ts
@@ -46,5 +46,6 @@ export class AnnotationTextCommentListComponent implements AfterViewInit {
 
   onTextCommentCreate() {
     this.create.emit(this.commentText);
+    this.commentText = '';
   }
 }

--- a/apps/koala-frontend/src/app/features/sessions/components/annotation-text-comment/annotation-text-comment.component.css
+++ b/apps/koala-frontend/src/app/features/sessions/components/annotation-text-comment/annotation-text-comment.component.css
@@ -7,6 +7,7 @@
   display: flex;
   justify-content: flex-end;
   align-items: center;
+  gap: 10px;
 }
 
 .full-width {
@@ -18,12 +19,18 @@
   color: #fff;
 }
 
-.remove-button {
+.comment-button {
   color: darkblue;
+}
+
+.comment-button:hover {
+  color: white;
 }
 
 .comment-info {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   justify-content: flex-start;
+  align-items: center;
+  min-width: 200px;
 }

--- a/apps/koala-frontend/src/app/features/sessions/components/annotation-text-comment/annotation-text-comment.component.css
+++ b/apps/koala-frontend/src/app/features/sessions/components/annotation-text-comment/annotation-text-comment.component.css
@@ -1,5 +1,5 @@
 .comment {
-  background-color: #fff;
+  background-color: #e5e5ea;
   border: 1px solid #e5e5ea;
   max-width: 600px;
   padding: 10px;

--- a/apps/koala-frontend/src/app/features/sessions/components/annotation-text-comment/annotation-text-comment.component.html
+++ b/apps/koala-frontend/src/app/features/sessions/components/annotation-text-comment/annotation-text-comment.component.html
@@ -9,25 +9,15 @@
   ></textarea>
   <div *ngIf="displayMode === DisplayMode.DISPLAY" class="comment-info">
     {{ comment.createdAt | date : 'short' }}
-    <button
-      pButton
-      *ngIf="comment.owner?.id === userId"
-      label="{{ 'SESSION.ANNOTATION.DETAIL_OVERLAY.EDIT_BTN' | translate }}"
-      class="p-button-link"
-      (click)="onEdit()"
-    ></button>
   </div>
   <div *ngIf="displayMode === DisplayMode.DISPLAY" class="comment" [class.own]="comment.owner?.id === userId">
     <span>{{ comment.text }}</span>
     <span *ngIf="comment.owner?.id === userId">
-      <button
-        pButton
-        pRipple
-        class="p-button-text remove-button"
-        (click)="onDelete()"
-        icon="pi pi-times-circle"
-      ></button
-    ></span>
+      <i class="pi pi-pencil comment-button" (click)="onEdit()"></i>
+    </span>
+    <span *ngIf="comment.owner?.id === userId">
+      <i class="pi pi-times-circle comment-button" (click)="onDelete($event)"></i>
+    </span>
   </div>
 </div>
 

--- a/apps/koala-frontend/src/app/features/sessions/components/annotation-text-comment/annotation-text-comment.component.html
+++ b/apps/koala-frontend/src/app/features/sessions/components/annotation-text-comment/annotation-text-comment.component.html
@@ -11,15 +11,16 @@
     {{ comment.createdAt | date : 'short' }}
     <button
       pButton
+      *ngIf="comment.owner?.id === userId"
       label="{{ 'SESSION.ANNOTATION.DETAIL_OVERLAY.EDIT_BTN' | translate }}"
       class="p-button-link"
       (click)="onEdit()"
     ></button>
   </div>
-  <div *ngIf="displayMode === DisplayMode.DISPLAY" class="comment own">
+  <div *ngIf="displayMode === DisplayMode.DISPLAY" class="comment" [class.own]="comment.owner?.id === userId">
     <span>{{ comment.text }}</span>
-    <span
-      ><button
+    <span *ngIf="comment.owner?.id === userId">
+      <button
         pButton
         pRipple
         class="p-button-text remove-button"

--- a/apps/koala-frontend/src/app/features/sessions/components/annotation-text-comment/annotation-text-comment.component.html
+++ b/apps/koala-frontend/src/app/features/sessions/components/annotation-text-comment/annotation-text-comment.component.html
@@ -16,7 +16,7 @@
       <i class="pi pi-pencil comment-button" (click)="onEdit()"></i>
     </span>
     <span *ngIf="comment.owner?.id === userId">
-      <i class="pi pi-times-circle comment-button" (click)="onDelete($event)"></i>
+      <i class="pi pi-times-circle comment-button" (click)="onDelete()"></i>
     </span>
   </div>
 </div>

--- a/apps/koala-frontend/src/app/features/sessions/components/annotation-text-comment/annotation-text-comment.component.ts
+++ b/apps/koala-frontend/src/app/features/sessions/components/annotation-text-comment/annotation-text-comment.component.ts
@@ -68,7 +68,7 @@ export class AnnotationTextCommentComponent {
     }
   }
 
-  onDelete(event: any) {
+  onDelete() {
     this.confirmationService.confirm({
       message: this.translateService.instant('SESSION.ANNOTATION.DETAIL_OVERLAY.DELETE_CONFIRM_DIALOG_MESSAGE'),
       header: this.translateService.instant('SESSION.ANNOTATION.DETAIL_OVERLAY.DELETE_CONFIRM_DIALOG_TITLE'),

--- a/apps/koala-frontend/src/app/features/sessions/components/annotation-text-comment/annotation-text-comment.component.ts
+++ b/apps/koala-frontend/src/app/features/sessions/components/annotation-text-comment/annotation-text-comment.component.ts
@@ -2,6 +2,8 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { DisplayMode } from '../../types/display-mode.enum';
 import { Comment } from '../../types/comment.entity';
 import { AuthService } from '../../../auth/services/auth.service';
+import { ConfirmationService } from 'primeng/api';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'koala-annotation-text-comment',
@@ -36,7 +38,11 @@ export class AnnotationTextCommentComponent {
   displayMode = DisplayMode.DISPLAY;
   DisplayMode = DisplayMode;
 
-  constructor(private readonly authService: AuthService) {
+  constructor(
+    private readonly authService: AuthService,
+    private readonly confirmationService: ConfirmationService,
+    private readonly translateService: TranslateService
+  ) {
     this.authService.me().subscribe({
       next: (data) => {
         this.userId = data.id;
@@ -62,8 +68,17 @@ export class AnnotationTextCommentComponent {
     }
   }
 
-  onDelete() {
-    this.delete.emit(this.comment.id);
+  onDelete(event: any) {
+    this.confirmationService.confirm({
+      message: this.translateService.instant('SESSION.ANNOTATION.DETAIL_OVERLAY.DELETE_CONFIRM_DIALOG_MESSAGE'),
+      header: this.translateService.instant('SESSION.ANNOTATION.DETAIL_OVERLAY.DELETE_CONFIRM_DIALOG_TITLE'),
+      icon: 'pi pi-exclamation-triangle',
+      rejectLabel: this.translateService.instant('SESSION.ANNOTATION.DETAIL_OVERLAY.DELETE_CONFIRM_DIALOG_REJECT'),
+      acceptLabel: this.translateService.instant('SESSION.ANNOTATION.DETAIL_OVERLAY.DELETE_CONFIRM_DIALOG_CONFIRM'),
+      accept: () => {
+        this.delete.emit(this.comment.id);
+      },
+    });
   }
 
   onEdit() {

--- a/apps/koala-frontend/src/app/features/sessions/components/annotation/annotation.component.html
+++ b/apps/koala-frontend/src/app/features/sessions/components/annotation/annotation.component.html
@@ -40,5 +40,3 @@
     (deleteAudioComment)="onAnnotationAudioCommentDelete($event)"
   ></koala-annotation-detail>
 </p-overlayPanel>
-
-<p-confirmDialog [style]="{ width: '50vw' }" rejectButtonStyleClass="p-button-outlined"></p-confirmDialog>

--- a/apps/koala-frontend/src/app/features/sessions/pages/session-analysis/session-analysis.page.html
+++ b/apps/koala-frontend/src/app/features/sessions/pages/session-analysis/session-analysis.page.html
@@ -24,6 +24,9 @@
         [currentTime]="currentAudioTime"
         [d3ContainerID]="userSession.id"
         [displayMode]="true"
+        (annotationTextCommentCreate)="onAnnotationTextCommentCreate($event)"
+        (annotationTextCommentUpdate)="onAnnotationTextCommentUpdate($event)"
+        (annotationTextCommentRemove)="onAnnotationTextCommentRemove($event)"
       ></koala-app-annotation>
     </div>
   </div>

--- a/apps/koala-frontend/src/app/features/sessions/pages/session-analysis/session-analysis.page.ts
+++ b/apps/koala-frontend/src/app/features/sessions/pages/session-analysis/session-analysis.page.ts
@@ -16,6 +16,8 @@ import { NavigationService } from '../../services/navigation.service';
 import { ToolbarsService } from '../../services/toolbars.service';
 import { UserSession } from '../../types/user-session.entity';
 import { CheckboxChangeEvent } from 'primeng/checkbox';
+import { CreateAnnotationTextComment } from '../../components/annotation-text-comment-list/annotation-text-comment-list.component';
+import { Comment } from '../../types/comment.entity';
 
 export interface AnnotationData {
   AnnotationData: Map<number, Array<DataPoint>>;
@@ -329,5 +331,38 @@ export class SessionAnalysisPage implements OnInit, OnDestroy {
         }
         break;
     }
+  }
+
+  onAnnotationTextCommentCreate(createComment: CreateAnnotationTextComment) {
+    this.annotationService.createComment(createComment.annotationId, createComment.text).subscribe({
+      next: () => {
+        this.sessionService.setFocusSession(parseInt(this.sessionService.getFocusSession()?.id || '0')).subscribe();
+      },
+      error: () => {
+        console.log('Error in Comment Creation');
+      },
+    });
+  }
+
+  onAnnotationTextCommentUpdate(comment: Comment) {
+    this.annotationService.updateComment(comment.id, comment.text).subscribe({
+      next: () => {
+        this.sessionService.setFocusSession(parseInt(this.sessionService.getFocusSession()?.id || '0')).subscribe();
+      },
+      error: () => {
+        console.log('Error in Comment Update');
+      },
+    });
+  }
+
+  onAnnotationTextCommentRemove(commentId: number) {
+    this.annotationService.removeComment(commentId).subscribe({
+      next: () => {
+        this.sessionService.setFocusSession(parseInt(this.sessionService.getFocusSession()?.id || '0')).subscribe();
+      },
+      error: () => {
+        console.log('Error in Comment Removal');
+      },
+    });
   }
 }

--- a/apps/koala-frontend/src/assets/i18n/de.json
+++ b/apps/koala-frontend/src/assets/i18n/de.json
@@ -223,7 +223,9 @@
         "DELETE_CONFIRM_DIALOG_TITLE": "Kommentar Löschen",
         "DELETE_CONFIRM_DIALOG_MESSAGE": "Wollen Sie den ausgewählten Kommentar löschen?",
         "DELETE_CONFIRM_DIALOG_CONFIRM": "Löschen",
-        "DELETE_CONFIRM_DIALOG_REJECT": "Abbrechen"
+        "DELETE_CONFIRM_DIALOG_REJECT": "Abbrechen",
+        "OWN_COMMENT_LEGEND": "Ich",
+        "OTHER_COMMENT_LEGEND": "Sessioneigentümer"
       }
     }
   },

--- a/apps/koala-frontend/src/assets/i18n/de.json
+++ b/apps/koala-frontend/src/assets/i18n/de.json
@@ -219,7 +219,11 @@
         "ANNOTATION_TIME_LABEL": "Zeit:",
         "AUDIO_COMMENT_TAB_TITLE": "Audio",
         "TEXT_COMMENT_TAB_TITLE": "Text",
-        "ALL_COMMENTS_TITLE": "Alle Kommentare"
+        "ALL_COMMENTS_TITLE": "Alle Kommentare",
+        "DELETE_CONFIRM_DIALOG_TITLE": "Kommentar Löschen",
+        "DELETE_CONFIRM_DIALOG_MESSAGE": "Wollen Sie den ausgewählten Kommentar löschen?",
+        "DELETE_CONFIRM_DIALOG_CONFIRM": "Löschen",
+        "DELETE_CONFIRM_DIALOG_REJECT": "Abbrechen"
       }
     }
   },


### PR DESCRIPTION
#448 

- Clears the input field after successful save
- Asks before deleting a comment the user to confirm
- Different coloring of owner and participant created annotation text comments
- Showing color legend for comments (my and session owner comment differentiation)