### PR TITLE
adds guard for unsaved changes

### DIFF
--- a/apps/koala-frontend/src/app/features/sessions/guards/session-unsaved-changes.guard.ts
+++ b/apps/koala-frontend/src/app/features/sessions/guards/session-unsaved-changes.guard.ts
@@ -1,0 +1,23 @@
+import { CanDeactivate } from '@angular/router';
+import { Observable } from 'rxjs';
+import { TranslateService } from '@ngx-translate/core';
+import { Injectable } from '@angular/core';
+
+export interface BlockNavigationIfUnsavedChanges {
+  hasUnsavedChanges(): boolean;
+}
+
+@Injectable({ providedIn: 'root' })
+export class UnsavedChangesGuard<T extends BlockNavigationIfUnsavedChanges> implements CanDeactivate<T> {
+  constructor(private readonly translateService: TranslateService) {}
+  canDeactivate(component: T): Observable<boolean> | boolean {
+    if (!component.hasUnsavedChanges()) {
+      return true;
+    }
+    if (window.confirm(this.translateService.instant('SESSION.UNSAVED_CHNAGES_WARNING'))) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+}

--- a/apps/koala-frontend/src/app/features/sessions/sessions-routing.module.ts
+++ b/apps/koala-frontend/src/app/features/sessions/sessions-routing.module.ts
@@ -6,6 +6,7 @@ import { SessionPage } from './pages/session/session.page';
 import { SessionInfoPage } from './pages/session-info/session-info.page';
 import { SessionAnalysisPage } from './pages/session-analysis/session-analysis.page';
 import { sessionOpenGuard } from './guards/session-open.guard';
+import { UnsavedChangesGuard } from './guards/session-unsaved-changes.guard';
 import { SessionNotFoundPage } from './pages/session-not-found/session-not-found.page';
 import { SessionNotActivePage } from './pages/session-not-active/session-not-active.page';
 
@@ -20,6 +21,9 @@ const routes: Routes = [
     component: SessionPage,
     canActivate: [
       sessionOpenGuard,
+    ],
+    canDeactivate: [
+      UnsavedChangesGuard,
     ],
   },
   {

--- a/apps/koala-frontend/src/assets/i18n/de.json
+++ b/apps/koala-frontend/src/assets/i18n/de.json
@@ -26,6 +26,7 @@
     "SESSION_NOT_YET_STARTED_INFO": "Die Session ist noch nicht gestartet",
     "SESSION_DOES_NOT_EXIST_INFO": "Die Session existiert nicht",
     "SESSION_CLOSED_INFO": "Die Session ist beendet",
+    "UNSAVED_CHNAGES_WARNING": "Es gbt ungesicherte Änderungen. Wollen Sie die Seite wirklich verlassen?",
     "SIDEBAR": {
       "SESSION_HEADER": "Freigaben",
       "SESSION_GENERAL_SETTINGS_TITLE": "Elemente",


### PR DESCRIPTION
fixes https://github.com/KoALa-MHF/koala-app/issues/278

warning for users on navigating or reloading session page when slider/range has not been saved.