### PR TITLE
Aligned MediaURL Source in Session Analysis Page to Session Page

### DIFF
--- a/apps/koala-frontend/src/app/features/sessions/pages/session-analysis/session-analysis.page.ts
+++ b/apps/koala-frontend/src/app/features/sessions/pages/session-analysis/session-analysis.page.ts
@@ -33,9 +33,7 @@ export interface AnnotationData {
   ],
 })
 export class SessionAnalysisPage implements OnInit, OnDestroy {
-  mediaUri: string = environment.production
-    ? 'https://koala.mh-freiburg.de/api/media'
-    : 'http://localhost:4200/api/media';
+  mediaUri: string = environment.mediaUrl;
   sessionId = 0;
   userID = -1;
   userSessionAnnotationData: Map<number, AnnotationData> = new Map<number, AnnotationData>();


### PR DESCRIPTION
Using directly the environment setting for mediaUrl in the session analysis page, which is used in the session page already.