### PR TITLE
Added ReferrerPolicy for Youtube iFrame Integration

### DIFF
--- a/apps/koala-frontend/src/app/features/sessions/services/media-control.service.ts
+++ b/apps/koala-frontend/src/app/features/sessions/services/media-control.service.ts
@@ -71,6 +71,7 @@ export class MediaControlService {
         mediaIFrame.style.width = '100%';
         mediaIFrame.style.height = '100%';
         mediaIFrame.style.border = 'none';
+        mediaIFrame.referrerPolicy = 'strict-origin-when-cross-origin';
         mediaIFrame.src = media?.name + '?enablejsapi=1' || '';
         mediaIFrame.allow =
           'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share';


### PR DESCRIPTION
The referrerPolicy of the apache configuration is that no referrer is sent in http requests. Youtube blocks such requests. To not change the apache setup completely when it is only necessary for the youtube integration, we can add the referrerPolicy on iFrame level:

referrerPolicy = 'strict-origin-when-cross-origin'

Solves #532 