### PR TITLE
Fixes Video Session End Slider and Range Annotations Issue

### DIFF
--- a/apps/koala-frontend/src/app/features/sessions/pages/session/session.page.ts
+++ b/apps/koala-frontend/src/app/features/sessions/pages/session/session.page.ts
@@ -298,6 +298,7 @@ export class SessionPage implements OnInit, OnDestroy, BlockNavigationIfUnsavedC
           .subscribe({
             next: () => {
               this.audioPaused = true;
+              this.endActiveSliders(this.currentAudioTime);
             },
           });
 
@@ -532,7 +533,6 @@ export class SessionPage implements OnInit, OnDestroy, BlockNavigationIfUnsavedC
           if (this.audioPaused) {
             this.sessionControlService.startSession().subscribe();
           } else {
-            this.endActiveSliders(this.currentAudioTime);
             this.sessionControlService.pauseSession().subscribe();
           }
           this.sessionService.setFocusSession(this.sessionId).subscribe();
@@ -542,7 +542,6 @@ export class SessionPage implements OnInit, OnDestroy, BlockNavigationIfUnsavedC
         break;
       case MediaActions.Stop:
         try {
-          this.endActiveSliders(this.currentAudioTime);
           this.sessionControlService.stopSession().subscribe();
           this.sessionService.setFocusSession(this.sessionId).subscribe();
           this.currentAudioTime = 0;


### PR DESCRIPTION
In video sessions annotations started for slider and range markers are not ended with pausing/stopping the video, and hence they are not saved. That led to missing annotations on the analysis page.