### PR TITLE
Fixes evaluation page missing markers and wrong user count (#541)

### DIFF
--- a/apps/api/src/app/user-sessions/user-sessions.service.ts
+++ b/apps/api/src/app/user-sessions/user-sessions.service.ts
@@ -127,8 +127,9 @@ export class UserSessionsService {
           ownerId: user?.id,
         },
         {
-          // or the session owner is allowed to see all user sessions
+          // or the session owner is allowed to see all user sessions (excluding orphaned records with no owner)
           sessionId: sessionId,
+          ownerId: Not(IsNull()),
           session: {
             ownerId: user?.id,
           },

--- a/apps/koala-frontend/src/app/features/sessions/guards/session-unsaved-changes.guard.ts
+++ b/apps/koala-frontend/src/app/features/sessions/guards/session-unsaved-changes.guard.ts
@@ -5,6 +5,7 @@ import { Injectable } from '@angular/core';
 
 export interface BlockNavigationIfUnsavedChanges {
   hasUnsavedChanges(): boolean;
+  saveUnsavedChanges(): Observable<boolean>;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -15,7 +16,7 @@ export class UnsavedChangesGuard<T extends BlockNavigationIfUnsavedChanges> impl
       return true;
     }
     if (window.confirm(this.translateService.instant('SESSION.UNSAVED_CHNAGES_WARNING'))) {
-      return true;
+      return component.saveUnsavedChanges();
     } else {
       return false;
     }

--- a/apps/koala-frontend/src/app/features/sessions/pages/session-analysis/session-analysis.page.ts
+++ b/apps/koala-frontend/src/app/features/sessions/pages/session-analysis/session-analysis.page.ts
@@ -179,7 +179,7 @@ export class SessionAnalysisPage implements OnInit, OnDestroy {
 
   private loadMarkerData(userSessions: any): void {
     const toolbars = this.session?.toolbars;
-    if (toolbars) {
+    if (toolbars && toolbars.length > 0) {
       const toolbar = toolbars[0];
       const toolbarMarkers = toolbar?.markers || [];
       const markerIds: Array<number> = toolbarMarkers.map((marker) => parseInt(marker.markerId));
@@ -196,6 +196,8 @@ export class SessionAnalysisPage implements OnInit, OnDestroy {
         ];
         this.loadAnnotations(userSessions);
       });
+    } else {
+      this.loadAnnotations(userSessions);
     }
   }
 

--- a/apps/koala-frontend/src/app/features/sessions/pages/session/session.page.ts
+++ b/apps/koala-frontend/src/app/features/sessions/pages/session/session.page.ts
@@ -14,7 +14,7 @@ import { Marker } from '../../types/marker.entity';
 import { MarkerType, PlayMode } from '../../../../graphql/generated/graphql';
 import { ToolbarMode } from '../../components/marker-toolbar/marker-toolbar.component';
 import { FormGroup, FormControl, FormBuilder } from '@angular/forms';
-import { filter, timer, Subscription } from 'rxjs';
+import { filter, forkJoin, map, of, timer, Observable, Subscription } from 'rxjs';
 import { ToolbarsService } from '../../services/toolbars.service';
 import { NavigationService } from '../../services/navigation.service';
 import { UserSession } from '../../types/user-session.entity';
@@ -241,6 +241,31 @@ export class SessionPage implements OnInit, OnDestroy, BlockNavigationIfUnsavedC
         return false;
       });
     });
+  }
+
+  saveUnsavedChanges(): Observable<boolean> {
+    const saves: Observable<unknown>[] = [];
+    this.AnnotationData.forEach((annotations, markerId) => {
+      annotations.forEach((annotation) => {
+        if (annotation.display !== Display.Circle && annotation.active) {
+          annotation.active = false;
+          annotation.endTime = Math.floor(this.currentAudioTime * 1000);
+          saves.push(
+            this.annotationService.create({
+              start: annotation.startTime,
+              end: annotation.endTime,
+              value: annotation.strength,
+              userSessionId: this.myUserSession?.id || 0,
+              markerId: markerId,
+            })
+          );
+        }
+      });
+    });
+    if (saves.length === 0) {
+      return of(true);
+    }
+    return forkJoin(saves).pipe(map(() => true));
   }
 
   @HostListener('window:beforeunload', [


### PR DESCRIPTION
Fixes #541

## Changes
- **Annotations lost on navigate**: Guard now calls `saveUnsavedChanges()` which awaits all pending GraphQL mutations via `forkJoin` before allowing navigation, instead of discarding active range/slider annotations
- **User rows not shown**: Analysis page now always calls `loadAnnotations()` (which sets `userSession.visible = true`) even when the session has no toolbar configured
- **Wrong user count**: Backend excludes orphaned user sessions (`ownerId IS NULL`) from the session owner's view