### PR TITLE
Fixed Missing Annotations on Navigation

### DIFF
--- a/apps/koala-frontend/src/app/features/sessions/guards/session-unsaved-changes.guard.ts
+++ b/apps/koala-frontend/src/app/features/sessions/guards/session-unsaved-changes.guard.ts
@@ -5,6 +5,7 @@ import { Injectable } from '@angular/core';
 
 export interface BlockNavigationIfUnsavedChanges {
   hasUnsavedChanges(): boolean;
+  endActiveSliders(time?: number): void;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -13,11 +14,9 @@ export class UnsavedChangesGuard<T extends BlockNavigationIfUnsavedChanges> impl
   canDeactivate(component: T): Observable<boolean> | boolean {
     if (!component.hasUnsavedChanges()) {
       return true;
-    }
-    if (window.confirm(this.translateService.instant('SESSION.UNSAVED_CHNAGES_WARNING'))) {
-      return true;
     } else {
-      return false;
+      component.endActiveSliders();
+      return true;
     }
   }
 }

--- a/apps/koala-frontend/src/app/features/sessions/pages/session/session.page.ts
+++ b/apps/koala-frontend/src/app/features/sessions/pages/session/session.page.ts
@@ -748,18 +748,20 @@ export class SessionPage implements OnInit, OnDestroy, BlockNavigationIfUnsavedC
     return this.sidePanelForm.get('markersArray') as FormGroup;
   }
 
-  endActiveSliders(time: number) {
+  endActiveSliders(time?: number) {
+    const currentTime = time ?? this.currentAudioTime ?? 0;
+
     this.AnnotationData.forEach((marker, id) => {
-      this.AnnotationData.get(id)?.forEach((annotation, i) => {
-        if (annotation.display == Display.Circle) {
+      this.AnnotationData.get(id)?.forEach((annotation) => {
+        if (annotation.display === Display.Circle) {
           return;
         }
         if (annotation.active) {
           annotation.active = false;
-          annotation.endTime = Math.floor(time * 1000);
+
+          annotation.endTime = Math.floor(currentTime * 1000);
           this.saveAnnotation(annotation, id);
         }
-        return;
       });
     });
   }


### PR DESCRIPTION
Slider and Range annotations were not saved when video session was still running and a navigation was triggered. The deactivate guard now triggers the "normal" end of sliders and range annotations as it would on stop or end of video.